### PR TITLE
Change modified dates to doubles

### DIFF
--- a/App/src/com/dozuki/ifixit/model/guide/GuideInfo.java
+++ b/App/src/com/dozuki/ifixit/model/guide/GuideInfo.java
@@ -16,9 +16,9 @@ public class GuideInfo implements Serializable {
    @SerializedName("revisionid")
    public int mRevisionid;
    @SerializedName("modified_date")
-   public int mModifiedDate;
+   public double mModifiedDate;
    @SerializedName("prereq_modified_date")
-   public int mPrereqModifiedDate;
+   public double mPrereqModifiedDate;
    @SerializedName("type")
    public String mType;
    @SerializedName("category")


### PR DESCRIPTION
Modified dates in the API are changing to doubles so they have more precision.
Unfortunately, GSON fails trying to parse a double into an int so we
must change the type to be compatible.
