### PR TITLE
Topic hierarchy: Use display titles

### DIFF
--- a/App/src/com/dozuki/ifixit/model/topic/TopicNode.java
+++ b/App/src/com/dozuki/ifixit/model/topic/TopicNode.java
@@ -8,6 +8,7 @@ public class TopicNode implements Serializable {
    protected static final String ROOT_NAME = "ROOT";
 
    private String mName;
+   private String mDisplayName;
    private ArrayList<TopicNode> mChildren;
 
    public TopicNode() {
@@ -16,10 +17,19 @@ public class TopicNode implements Serializable {
 
    public TopicNode(String name) {
       mName = name;
+      mDisplayName = name;
    }
 
    public String getName() {
       return mName;
+   }
+
+   public String getDisplayName() {
+      return mDisplayName;
+   }
+
+   public void setDisplayName(String displayName) {
+      mDisplayName = displayName;
    }
 
    public ArrayList<TopicNode> getChildren() {

--- a/App/src/com/dozuki/ifixit/ui/topic_view/TopicActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/topic_view/TopicActivity.java
@@ -137,7 +137,7 @@ public class TopicActivity extends BaseSearchMenuDrawerActivity
    public void onTopicSelected(TopicNode topic) {
       if (topic.isLeaf()) {
          if (mDualPane) {
-            showTopicLoading(topic.getName());
+            showTopicLoading(topic.getDisplayName());
             mTopicView.setTopicNode(topic);
 
             if (mHideTopicList) {
@@ -153,7 +153,7 @@ public class TopicActivity extends BaseSearchMenuDrawerActivity
          }
       } else {
          if (mDualPane && !topic.isRoot()) {
-            showTopicLoading(topic.getName());
+            showTopicLoading(topic.getDisplayName());
 
             mTopicView.setTopicNode(topic);
          }

--- a/App/src/com/dozuki/ifixit/ui/topic_view/TopicListAdapter.java
+++ b/App/src/com/dozuki/ifixit/ui/topic_view/TopicListAdapter.java
@@ -59,7 +59,7 @@ public class TopicListAdapter extends Section {
 
       topicName = (TextView)row.findViewById(R.id.topic_title);
 
-      topicName.setText(mTopicList.get(position).getName());
+      topicName.setText(mTopicList.get(position).getDisplayName());
 
       return row;
    }

--- a/App/src/com/dozuki/ifixit/ui/topic_view/TopicListFragment.java
+++ b/App/src/com/dozuki/ifixit/ui/topic_view/TopicListFragment.java
@@ -74,6 +74,8 @@ public class TopicListFragment extends BaseFragment
    }
 
    private void setupTopicAdapter() {
+      // TODO: A lot of of this is specific to iFixit so it should probably
+      // be moved to the iFixit block.
       mTopicAdapter = new SectionHeadersAdapter();
       ArrayList<TopicNode> generalInfo = new ArrayList<TopicNode>();
       ArrayList<TopicNode> nonLeaves = new ArrayList<TopicNode>();
@@ -88,6 +90,9 @@ public class TopicListFragment extends BaseFragment
          }
       }
 
+      // The sorting is necessary because JSON objects are inherently unorderd.
+      // The API returns them in the correct order but no JSON implementation
+      // will respect the order of the elements.
       Comparator<TopicNode> comparator = new Comparator<TopicNode>() {
          public int compare(TopicNode first, TopicNode second) {
             return first.getName().compareToIgnoreCase(second.getName());
@@ -98,7 +103,10 @@ public class TopicListFragment extends BaseFragment
       Collections.sort(leaves, comparator);
 
       if (!mTopic.isRoot() && !((TopicActivity)getActivity()).isDualPane()) {
-         generalInfo.add(new TopicNode(mTopic.getName()));
+         TopicNode generalTopicNode = new TopicNode(mTopic.getName());
+         generalTopicNode.setDisplayName(mTopic.getDisplayName());
+
+         generalInfo.add(generalTopicNode);
          adapter = new TopicListAdapter(mContext, mContext.getString(
           R.string.generalInformation), generalInfo);
          adapter.setTopicSelectedListener(this);
@@ -164,7 +172,7 @@ public class TopicListFragment extends BaseFragment
 
       getSherlockActivity().setTitle(mTopic.getName().equals("ROOT") ?
        MainApplication.get().getSite().mTitle :
-       mTopic.getName());
+       mTopic.getDisplayName());
 
       setupTopicAdapter();
       mListView.setAdapter(mTopicAdapter);

--- a/App/src/com/dozuki/ifixit/ui/topic_view/TopicViewActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/topic_view/TopicViewActivity.java
@@ -44,7 +44,7 @@ public class TopicViewActivity extends BaseSearchMenuDrawerActivity {
       mTopicNode = (TopicNode)getIntent().getSerializableExtra(TOPIC_KEY);
 
       if (mTopicNode != null) {
-         setTitle(mTopicNode.getName());
+         setTitle(mTopicNode.getDisplayName());
 
          MainApplication.getGaTracker().set(Fields.SCREEN_NAME, "/category/" + mTopicNode.getName());
       }

--- a/App/src/com/dozuki/ifixit/util/APIEndpoint.java
+++ b/App/src/com/dozuki/ifixit/util/APIEndpoint.java
@@ -33,7 +33,7 @@ public enum APIEndpoint {
    CATEGORIES(
       new Endpoint() {
          public String createUrl(String query) {
-            return "categories";
+            return "categories?withDisplayTitles";
          }
 
          public APIEvent<?> parse(String json) throws JSONException {

--- a/App/src/com/dozuki/ifixit/util/JSONHelper.java
+++ b/App/src/com/dozuki/ifixit/util/JSONHelper.java
@@ -340,8 +340,11 @@ public class JSONHelper {
     * Topic hierarchy parsing
     */
    public static TopicNode parseTopics(String json) throws JSONException {
-      JSONObject jTopics = new JSONObject(json);
-      ArrayList<TopicNode> topics = parseTopicChildren(jTopics);
+      JSONObject jResponse = new JSONObject(json);
+      JSONObject jHierarchy = jResponse.getJSONObject("hierarchy");
+      JSONObject jDisplayNames = jResponse.getJSONObject("display_titles");
+
+      ArrayList<TopicNode> topics = parseTopicChildren(jHierarchy, jDisplayNames);
       TopicNode root = new TopicNode();
 
       root.setChildren(topics);
@@ -352,13 +355,8 @@ public class JSONHelper {
    /**
     * Reads through the given JSONObject and adds any topics to the given topic.
     */
-   private static ArrayList<TopicNode> parseTopicChildren(JSONObject jTopic)
-    throws JSONException {
-      // Don't allocate any lists if it's empty.
-      if (jTopic.length() == 0) {
-         return null;
-      }
-
+   private static ArrayList<TopicNode> parseTopicChildren(JSONObject jTopic,
+    JSONObject jDisplayNames) throws JSONException {
       @SuppressWarnings("unchecked")
       Iterator<String> iterator = jTopic.keys();
       String topicName;
@@ -369,7 +367,15 @@ public class JSONHelper {
          topicName = iterator.next();
 
          currentTopic = new TopicNode(topicName);
-         currentTopic.setChildren(parseTopicChildren(jTopic.getJSONObject(topicName)));
+
+         if (!jTopic.isNull(topicName)) {
+            currentTopic.setChildren(parseTopicChildren(jTopic.getJSONObject(topicName),
+             jDisplayNames));
+         }
+
+         if (jDisplayNames.has(topicName)) {
+            currentTopic.setDisplayName(jDisplayNames.getString(topicName));
+         }
 
          topics.add(currentTopic);
       }


### PR DESCRIPTION
Now display titles are respected when drilling down the content
hierarchy.
