### PR TITLE
Proguard: Run in release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ keystore
 build.xml
 ant.properties
 local.properties
-proguard.cfg
 proguard-project.txt
 
 #Other

--- a/App/build.gradle
+++ b/App/build.gradle
@@ -65,6 +65,9 @@ android {
 
       release {
          buildConfig 'public static final String DEV_SERVER = "";'
+
+         runProguard true
+         proguardFile 'proguard.cfg'
       }
    }
 

--- a/App/proguard.cfg
+++ b/App/proguard.cfg
@@ -1,0 +1,80 @@
+# This is a configuration file for ProGuard.
+# http://proguard.sourceforge.net/index.html#manual/usage.html
+
+-dontusemixedcaseclassnames
+-dontskipnonpubliclibraryclasses
+-verbose
+
+# Optimization is turned off by default. Dex does not like code run
+# through the ProGuard optimize and preverify steps (and performs some
+# of these optimizations on its own).
+-dontoptimize
+-dontpreverify
+# Note that if you want to enable optimization, you cannot just
+# include optimization flags in your own project configuration file;
+# instead you will need to point to the
+# "proguard-android-optimize.txt" file instead of this one from your
+# project.properties file.
+
+-keepattributes *Annotation*
+-keep public class com.google.vending.licensing.ILicensingService
+-keep public class com.android.vending.licensing.ILicensingService
+
+# For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# keep setters in Views so that animations can still work.
+# see http://proguard.sourceforge.net/manual/examples.html#beans
+-keepclassmembers public class * extends android.view.View {
+   void set*(***);
+   *** get*();
+}
+
+# We want to keep methods in Activity that could be used in the XML attribute onClick
+-keepclassmembers class * extends android.app.Activity {
+   public void *(android.view.View);
+}
+
+# For enumeration classes, see http://proguard.sourceforge.net/manual/examples.html#enumerations
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+-keep class * implements android.os.Parcelable {
+  public static final android.os.Parcelable$Creator *;
+}
+
+-keepclassmembers class **.R$* {
+    public static <fields>;
+}
+
+# The support library contains references to newer platform versions.
+# Don't warn about those in case this app is linking against an older
+# platform version.  We know about them, and they are safe.
+-dontwarn android.support.**
+
+
+# iFixit Changes
+-dontobfuscate
+
+# ActionBarSherlock
+-keep class android.support.v4.app.** { *; }
+-keep interface android.support.v4.app.** { *; }
+-keep class com.actionbarsherlock.** { *; }
+-keep interface com.actionbarsherlock.** { *; }
+
+-dontwarn com.actionbarsherlock.internal.**
+
+# Otto
+-keepclassmembers class ** {
+    @com.squareup.otto.Subscribe public *;
+    @com.squareup.otto.Produce public *;
+}
+
+# ZXing
+# This is referenced by Reflection because the library is only included for
+# apps that use it.
+-keep class com.google.zxing.integration.android.** { *; }


### PR DESCRIPTION
For us, the primary benefit of running proguard is to remove unused
methods. This is particularly important to remove library code that we
never reference.

This drops APK size of iFixit from 3.5MB to 3.1MB and Dozuki from
4.7MB to 4.1MB.
