### PR TITLE
Step edit text: Remove autoComplete

### DIFF
--- a/App/res/layout/guide_create_step_edit_line.xml
+++ b/App/res/layout/guide_create_step_edit_line.xml
@@ -29,7 +29,7 @@
         android:layout_toLeftOf="@+id/step_line_mic_button"
         android:hint="@string/step_text_default"
         android:imeOptions="actionDone"
-        android:inputType="text|textMultiLine|textAutoComplete|textAutoCorrect|textCapSentences"/>
+        android:inputType="textMultiLine|textAutoCorrect|textCapSentences"/>
 
     <ImageButton
         android:id="@+id/step_line_mic_button"


### PR DESCRIPTION
http://stackoverflow.com/questions/13831955/using-textautocorrect-and-textautocomplete-together-in-android

Apparently textAutoCorrect and textAutoComplete are mutually exclusive
and textAutoComplete takes precedence. Turns out, textAutoComplete
doesn't get us much of anything unless we want to add a custom glossary
for completion choices. textAutoCorrect gives us auto correction and
"double space to period space" that is really useful.

Note: This is now the same as the step title with "textMultiLine"
rather than "textShortMessage". Also, I removed "text" because
"textMultiLine" implies "text".
