### PR TITLE
Fix Teardown intent filtering

### DIFF
--- a/App/src/com/dozuki/ifixit/ui/IntentFilterActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/IntentFilterActivity.java
@@ -93,7 +93,7 @@ public class IntentFilterActivity extends BaseActivity {
       String prefix = segments.get(0);
 
       try {
-         if (prefix.equalsIgnoreCase("guide")) {
+         if (prefix.equalsIgnoreCase("guide") || prefix.equalsIgnoreCase("teardown")) {
             if (segments.get(1).equalsIgnoreCase("search")) {
                String query = segments.get(2);
                intent = SearchActivity.viewSearch(this, query);


### PR DESCRIPTION
In my [refactoring of intent filtering](de5dff3d4a5ef58d0c7cde5e9695dfacdc5ecd40), I introduced a bug that causes teardown URLs (e.g. `/Teardown/Macintosh+128K+Teardown/21422`) to not open guides correctly. We just need to check for `teardown` as well as `guide` to match a guide view URL.
