### PR TITLE
Always ensure guide exists before saving step

### DIFF
--- a/App/src/com/dozuki/ifixit/ui/guide/create/StepEditActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/guide/create/StepEditActivity.java
@@ -985,7 +985,6 @@ public class StepEditActivity extends BaseMenuDrawerActivity implements OnClickL
               dialog.dismiss();
               switch (dialogType) {
                  case NEW_STEP:
-                    addNewStep(mPagePosition + 1);
                     mAddStepAfterSave = true;
                     break;
                  case NEXT_STEP:


### PR DESCRIPTION
1. Create New Guide
2. Enter some step content
3. Hit the plus to create a new step.
4. Hit "Yes" to save the current step.
5. Crash.

Now we always ensure that the guide exists before trying to save a step
and everything works itself out.
