### PR TITLE
Dozuki: Fix QR Code Scanner dependency

### DIFF
--- a/App/build.gradle
+++ b/App/build.gradle
@@ -93,8 +93,8 @@ android {
 
    productFlavors.dozuki.ext {
       dependencies {
-         accustreamCompile 'com.embarkmobile:zxing-android-minimal:1.1.4@aar'
-         accustreamCompile 'com.google.zxing:core:2.2'
+         dozukiCompile 'com.embarkmobile:zxing-android-minimal:1.1.4@aar'
+         dozukiCompile 'com.google.zxing:core:2.2'
       }
 
       minSdkVersion = 9


### PR DESCRIPTION
Just a simple copypasta error that resulted in Dozuki without the ZXing
library which renders the QR code scanner feature useless.
