### PR TITLE
SSO login: Fix webview

### DIFF
--- a/App/res/layout/open_id_view.xml
+++ b/App/res/layout/open_id_view.xml
@@ -2,6 +2,5 @@
 <WebView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/open_id_web_view"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" >
-
+    android:layout_height="match_parent" >
 </WebView>

--- a/App/src/com/dozuki/ifixit/ui/login/OpenIDActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/login/OpenIDActivity.java
@@ -27,6 +27,7 @@ public class OpenIDActivity extends Activity {
    public void onCreate(Bundle savedInstanceState) {
       super.onCreate(savedInstanceState);
       setContentView(R.layout.open_id_view);
+      setTitle(R.string.login);
       overridePendingTransition(R.anim.slide_in_bottom, R.anim.slide_out_bottom);
       Bundle extras = getIntent().getExtras();
 
@@ -49,25 +50,22 @@ public class OpenIDActivity extends Activity {
       CookieSyncManager.getInstance().sync();
       CookieManager.getInstance().removeAllCookie();
 
-      mWebView.loadUrl(loginUrl);
-      mWebView.getSettings().setJavaScriptEnabled(true);
+      WebSettings settings = mWebView.getSettings();
+      settings.setJavaScriptEnabled(true);
+      settings.setBuiltInZoomControls(true);
+      settings.setSupportZoom(true);
+      settings.setLoadWithOverviewMode(true);
+      settings.setUseWideViewPort(true);
+      settings.setAppCacheEnabled(true);
+      settings.setCacheMode(WebSettings.LOAD_DEFAULT);
 
-      mWebView.setWebChromeClient(new WebChromeClient() {
-         // Show loading progress in activity's title bar.
-         @Override
-         public void onProgressChanged(WebView view, int progress) {
-            setProgress(progress * 100);
-         }
-      });
       mWebView.setWebViewClient(new WebViewClient() {
          // When start to load page, show url in activity's title bar
          @Override
          public void onPageStarted(WebView view, String url, Bitmap favicon) {
             setTitle(url);
          }
-      });
 
-      mWebView.setWebViewClient(new WebViewClient() {
          @Override
          public void onPageFinished(WebView view, String url) {
             CookieSyncManager.getInstance().sync();
@@ -110,5 +108,7 @@ public class OpenIDActivity extends Activity {
             finish();
          }
       });
+
+      mWebView.loadUrl(loginUrl);
    }
 }


### PR DESCRIPTION
I'm not sure what exactly what caused the issue, but the WebView used to
display OpenID/SSO login wasn't displaying any content.

I think it was ultimately a combination of the following:
- Upgrading to 4.4 which uses Chrome for the default WebView client
- Loading pages with insecure content
- Layout width
- Overriding the WebChromeClient
- Not specifying a wide viewport

At any rate, this code is more consistent with the other WebView we use
for displaying Answers and no longer exhibits any of the aforementioned
problems.
