### PR TITLE
Barcode scanner: Fix failing scan result parsing

### DIFF
--- a/App/src/com/dozuki/ifixit/ui/BaseMenuDrawerActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/BaseMenuDrawerActivity.java
@@ -147,6 +147,11 @@ public abstract class BaseMenuDrawerActivity extends BaseActivity
          Method parseResult = c.getDeclaredMethod("parseActivityResult", argTypes);
          Object intentResult = parseResult.invoke(null, requestCode, resultCode, intent);
 
+         // The request code didn't match.
+         if (intentResult == null) {
+            return null;
+         }
+
          // Call intentResult.getContents().
          c = Class.forName("com.google.zxing.integration.android.IntentResult");
          argTypes = new Class[]{};


### PR DESCRIPTION
1. Go to the Media Manager.
2. Add an image from the Gallery.
3. A "Failed to parse result" toast is displayed but everything works as
   expected.

This is caused by the ZXing library parsing the Activity result but
returning a null `IntentResult` because the request codes didn't match.
The app didn't crash because the parsing code is all wrapped in a
try/catch to swallow all errors because of the tricky reflection. This
fixes the bug which removes the awkward Toast.
