### PR TITLE
Step edit: Fix focus-induced jumping

### DIFF
--- a/App/res/layout/guide_create_step_edit_lines.xml
+++ b/App/res/layout/guide_create_step_edit_lines.xml
@@ -6,9 +6,6 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:descendantFocusability="beforeDescendants"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
         android:orientation="vertical"
         android:gravity="center_horizontal">
 


### PR DESCRIPTION
1. Open step edit on a step with lots of text.
2. Focus is given to the step title EditText which causes the view to
   jump down and hide the images.

The timing is especially awkward on this because everything is peachy
until ~0.5 seconds after the page is swiped over -- _then_ it jumps down
in a disorienting fashion.

Removing all focus-related attributes on the title fixed it while still
giving it the primary focus.
