### PR TITLE
Guide view: Fix restore fragment state crash

### DIFF
--- a/App/src/android/support/v4/app/FixedFragmentStatePagerAdapter.java
+++ b/App/src/android/support/v4/app/FixedFragmentStatePagerAdapter.java
@@ -1,0 +1,25 @@
+package android.support.v4.app;
+
+import android.os.Bundle;
+import android.view.ViewGroup;
+
+/**
+ * Fix for rare bug involving Fragment state.
+ *
+ * https://code.google.com/p/android/issues/detail?id=37484#c1
+ */
+public abstract class FixedFragmentStatePagerAdapter extends FragmentStatePagerAdapter {
+   public FixedFragmentStatePagerAdapter(FragmentManager fm) {
+      super(fm);
+   }
+
+   @Override
+   public Object instantiateItem(ViewGroup container, int position) {
+      Fragment fragment = (Fragment)super.instantiateItem(container, position);
+      Bundle savedFragmentState = fragment.mSavedFragmentState;
+      if (savedFragmentState != null) {
+         savedFragmentState.setClassLoader(fragment.getClass().getClassLoader());
+      }
+      return fragment;
+   }
+}

--- a/App/src/com/dozuki/ifixit/ui/gallery/GalleryActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/gallery/GalleryActivity.java
@@ -5,7 +5,7 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FixedFragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.view.ViewGroup;
 import com.actionbarsherlock.view.ActionMode;
@@ -139,7 +139,7 @@ public class GalleryActivity extends BaseMenuDrawerActivity {
    /**
     * Why in the world is this class called StepAdapter?
     */
-   public class StepAdapter extends FragmentStatePagerAdapter {
+   public class StepAdapter extends FixedFragmentStatePagerAdapter {
 
       public StepAdapter(FragmentManager fm) {
          super(fm);

--- a/App/src/com/dozuki/ifixit/ui/guide/create/GuideIntroActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/guide/create/GuideIntroActivity.java
@@ -5,7 +5,7 @@ import android.content.pm.ActivityInfo;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FixedFragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.util.TypedValue;
 import android.view.View;
@@ -367,7 +367,7 @@ public class GuideIntroActivity extends BaseMenuDrawerActivity implements
    // ADAPTERS
    /////////////////////////////////////////////////////
 
-   public class FormWizardPagerAdapter extends FragmentStatePagerAdapter {
+   public class FormWizardPagerAdapter extends FixedFragmentStatePagerAdapter {
       private int mCutOffPage;
       private Fragment mPrimaryItem;
 

--- a/App/src/com/dozuki/ifixit/ui/guide/create/StepEditActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/guide/create/StepEditActivity.java
@@ -12,7 +12,7 @@ import android.speech.RecognizerIntent;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FixedFragmentStatePagerAdapter;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
@@ -843,7 +843,7 @@ public class StepEditActivity extends BaseMenuDrawerActivity implements OnClickL
       mPagePosition = position;
    }
 
-   private class StepAdapter extends FragmentStatePagerAdapter {
+   private class StepAdapter extends FixedFragmentStatePagerAdapter {
       private Map<Integer, String> mPageLabelMap;
 
       public StepAdapter(FragmentManager fm) {

--- a/App/src/com/dozuki/ifixit/ui/guide/view/GuideViewAdapter.java
+++ b/App/src/com/dozuki/ifixit/ui/guide/view/GuideViewAdapter.java
@@ -2,7 +2,7 @@ package com.dozuki.ifixit.ui.guide.view;
 
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FixedFragmentStatePagerAdapter;
 import android.view.View;
 
 import com.dozuki.ifixit.App;
@@ -12,7 +12,7 @@ import com.dozuki.ifixit.model.guide.Guide;
 import java.util.HashMap;
 import java.util.Map;
 
-public class GuideViewAdapter extends FragmentStatePagerAdapter {
+public class GuideViewAdapter extends FixedFragmentStatePagerAdapter {
    private static final int GUIDE_INTRO_POSITION = 0;
    private Map<Integer, String> mPageLabelMap;
 

--- a/App/src/com/dozuki/ifixit/ui/topic_view/TopicViewFragment.java
+++ b/App/src/com/dozuki/ifixit/ui/topic_view/TopicViewFragment.java
@@ -3,7 +3,7 @@ package com.dozuki.ifixit.ui.topic_view;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FixedFragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -198,7 +198,7 @@ public class TopicViewFragment extends BaseFragment implements ViewPager.OnPageC
       return mTopicNode;
    }
 
-   public class PageAdapter extends FragmentStatePagerAdapter {
+   public class PageAdapter extends FixedFragmentStatePagerAdapter {
       private Map<Integer, String> mPageLabelMap;
 
       public PageAdapter(FragmentManager fm) {


### PR DESCRIPTION
We've had several puzzling crash reports for a while:
`android.os.BadParcelableException: ClassNotFoundException when unmarshalling: android.support.v4.app.FragmentManagerState`

I finally reproduced it:
1. Enable `Settings` -> `Developer options` -> `Don't keep activities`.
2. Open guide view.
3. Click on a part or tool.
4. Hit back.
5. Swipe to other steps and back.
6. Go to 3.

In my experience it takes 2 tries to get it to crash. Turns out it's a
bug in the support library:
https://code.google.com/p/android/issues/detail?id=37484#c1

The upside is that it's an easy fix. The downside is that we have to
extend the class at `android.v4.app.FixedFragmentStatePagerAdapter` and
use that one in place of the default implementation.
