### PR TITLE
Display debug mode indicator in menu drawer

### DIFF
--- a/App/res/values/strings.xml
+++ b/App/res/values/strings.xml
@@ -281,6 +281,7 @@
     <string name="parts_and_tools"><![CDATA[Parts & Tools]]></string>
     <string name="create_new_guide">Create New Guide</string>
     <string name="new_guide">New Guide</string>
+    <string name="debug">Debug</string>
 
     <string-array name="new_image_actions">
         <item>Camera</item>

--- a/App/src/com/dozuki/ifixit/ui/BaseMenuDrawerActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/BaseMenuDrawerActivity.java
@@ -15,8 +15,10 @@ import android.widget.BaseAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import com.actionbarsherlock.view.MenuItem;
 import com.dozuki.ifixit.App;
+import com.dozuki.ifixit.BuildConfig;
 import com.dozuki.ifixit.R;
 import com.dozuki.ifixit.model.user.LoginEvent;
 import com.dozuki.ifixit.ui.gallery.GalleryActivity;
@@ -27,6 +29,7 @@ import com.dozuki.ifixit.ui.guide.view.TeardownsActivity;
 import com.dozuki.ifixit.ui.search.SearchActivity;
 import com.dozuki.ifixit.ui.topic_view.TopicActivity;
 import com.google.analytics.tracking.android.MapBuilder;
+
 import net.simonvt.menudrawer.MenuDrawer;
 import net.simonvt.menudrawer.Position;
 
@@ -398,6 +401,14 @@ public abstract class BaseMenuDrawerActivity extends BaseActivity
          @Override
          public boolean shouldDisplay() {
             return App.get().getSite().isIfixit();
+         }
+      },
+
+      // Display a separator so we know that the app is in debug mode.
+      DEBUG_SEPARATOR(R.string.debug) {
+         @Override
+         public boolean shouldDisplay() {
+            return BuildConfig.DEBUG;
          }
       };
 


### PR DESCRIPTION
Without this there isn't an easy way to determine if the app is in debug
mode or not. This change was prompted by realizing halfway through
testing the app that it was in release mode rather than debug mode.
Fortunately I didn't cause any damage in the meantime.

[Screen shot](https://f.cloud.github.com/assets/1094445/2390249/0aa2faf8-a958-11e3-875b-2f46ded80110.png)
