### PR TITLE
Guide Publish: Fix orientation change crash

### DIFF
--- a/App/src/com/dozuki/ifixit/ui/guide/create/StepEditActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/guide/create/StepEditActivity.java
@@ -535,7 +535,11 @@ public class StepEditActivity extends BaseMenuDrawerActivity implements OnClickL
       hideLoading();
 
       // Re-enable the toggle view
-      findViewById(R.id.publish_toggle).setEnabled(true);
+      View publishToggle = findViewById(R.id.publish_toggle);
+
+      if (publishToggle != null) {
+         publishToggle.setEnabled(true);
+      }
 
       // Update guide even if there is a conflict.
       if (!event.hasError() || event.getError().mType == ApiError.Type.CONFLICT) {


### PR DESCRIPTION
To reproduce:
- Tap the "public/private" toggle
- Change phone orientation before loading is done
- Crash.
