### PR TITLE
Category hierarchy: Respect display order

### DIFF
--- a/App/src/com/dozuki/ifixit/ui/topic_view/TopicListFragment.java
+++ b/App/src/com/dozuki/ifixit/ui/topic_view/TopicListFragment.java
@@ -21,8 +21,6 @@ import com.marczych.androidsectionheaders.SectionHeadersAdapter;
 import com.marczych.androidsectionheaders.SectionListView;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 
 public class TopicListFragment extends BaseFragment
  implements TopicSelectedListener, OnItemClickListener {
@@ -92,18 +90,6 @@ public class TopicListFragment extends BaseFragment
          }
       }
 
-      // The sorting is necessary because JSON objects are inherently unorderd.
-      // The API returns them in the correct order but no JSON implementation
-      // will respect the order of the elements.
-      Comparator<TopicNode> comparator = new Comparator<TopicNode>() {
-         public int compare(TopicNode first, TopicNode second) {
-            return first.getName().compareToIgnoreCase(second.getName());
-         }
-      };
-
-      Collections.sort(nonLeaves, comparator);
-      Collections.sort(leaves, comparator);
-
       if (!mTopic.isRoot() && !((TopicActivity)getActivity()).isDualPane()) {
          TopicNode generalTopicNode = new TopicNode(mTopic.getName());
          generalTopicNode.setDisplayName(mTopic.getDisplayName());
@@ -131,7 +117,6 @@ public class TopicListFragment extends BaseFragment
             mTopicAdapter.addSection(adapter);
          }
       } else {
-         Collections.sort(mTopic.getChildren(), comparator);
          adapter = new TopicListAdapter(mContext, App.get().getSite().getObjectNamePlural(),
           mTopic.getChildren());
          adapter.setTopicSelectedListener(this);

--- a/App/src/com/dozuki/ifixit/util/JSONHelper.java
+++ b/App/src/com/dozuki/ifixit/util/JSONHelper.java
@@ -334,11 +334,9 @@ public class JSONHelper {
     * Topic hierarchy parsing
     */
    public static TopicNode parseTopics(String json) throws JSONException {
-      JSONObject jResponse = new JSONObject(json);
-      JSONObject jHierarchy = jResponse.getJSONObject("hierarchy");
-      JSONObject jDisplayNames = jResponse.getJSONObject("display_titles");
+      JSONArray jHierarchy = new JSONArray(json);
 
-      ArrayList<TopicNode> topics = parseTopicChildren(jHierarchy, jDisplayNames);
+      ArrayList<TopicNode> topics = parseTopicChildren(jHierarchy);
       TopicNode root = new TopicNode();
 
       root.setChildren(topics);
@@ -349,29 +347,22 @@ public class JSONHelper {
    /**
     * Reads through the given JSONObject and adds any topics to the given topic.
     */
-   private static ArrayList<TopicNode> parseTopicChildren(JSONObject jTopic,
-    JSONObject jDisplayNames) throws JSONException {
-      @SuppressWarnings("unchecked")
-      Iterator<String> iterator = jTopic.keys();
-      String topicName;
+   private static ArrayList<TopicNode> parseTopicChildren(JSONArray jChildren) throws JSONException {
       ArrayList<TopicNode> topics = new ArrayList<TopicNode>();
-      TopicNode currentTopic;
 
-      while (iterator.hasNext()) {
-         topicName = iterator.next();
+      for (int i = 0; i < jChildren.length(); i++) {
+         JSONObject jTopic = jChildren.getJSONObject(i);
+         TopicNode topic = new TopicNode(jTopic.getString("title"));
 
-         currentTopic = new TopicNode(topicName);
-
-         if (!jTopic.isNull(topicName)) {
-            currentTopic.setChildren(parseTopicChildren(jTopic.getJSONObject(topicName),
-             jDisplayNames));
+         if (jTopic.has("children")) {
+            topic.setChildren(parseTopicChildren(jTopic.getJSONArray("children")));
          }
 
-         if (jDisplayNames.has(topicName)) {
-            currentTopic.setDisplayName(jDisplayNames.getString(topicName));
+         if (jTopic.has("display_title")) {
+            topic.setDisplayName(jTopic.getString("display_title"));
          }
 
-         topics.add(currentTopic);
+         topics.add(topic);
       }
 
       return topics;

--- a/App/src/com/dozuki/ifixit/util/api/ApiEndpoint.java
+++ b/App/src/com/dozuki/ifixit/util/api/ApiEndpoint.java
@@ -35,7 +35,7 @@ public enum ApiEndpoint {
    CATEGORIES(
       new Endpoint() {
          public String createUrl(String query) {
-            return "categories?withDisplayTitles";
+            return "wikis/CATEGORY?display=hierarchyOrder";
          }
 
          public ApiEvent<?> parse(String json) throws JSONException {


### PR DESCRIPTION
Because of the inherently unordered nature of JSON objects, we couldn't
respect the display order of the category hierarchy. This switches the
hierarchy response to a new endpoint that uses arrays to specify the
order of the children. This removes the need to perform a
lexicographical sort on the children before displaying them in the list.

Note: This is blocked on deploying the new API endpoint.
