### PR TITLE
Intent filters: Add analytics

### DIFF
--- a/App/src/com/dozuki/ifixit/ui/IntentFilterActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/IntentFilterActivity.java
@@ -114,13 +114,16 @@ public class IntentFilterActivity extends BaseActivity {
             if (segments.get(1).equalsIgnoreCase("search")) {
                String query = segments.get(2);
                intent = SearchActivity.viewSearch(this, query);
+               App.sendEvent("ui_action", "intent_filter", "search", null);
             } else {
                int guideid = Integer.parseInt(segments.get(2).trim());
                intent = GuideViewActivity.viewGuideid(this, guideid);
+               App.sendEvent("ui_action", "intent_filter", "guide", null);
             }
          } else if (prefix.equalsIgnoreCase("c") || prefix.equalsIgnoreCase("device")) {
             String topicName = segments.get(1);
             intent = TopicViewActivity.viewTopic(this, topicName);
+            App.sendEvent("ui_action", "intent_filter", "category", null);
          }
       } catch (Exception e) {
          App.sendException("IntentFilterActivity", "Problem parsing Uri", e);


### PR DESCRIPTION
This adds analytics to the intent filters so we know how often users
take advantage of the URL matching we do for viewing guides, devices,
and search results.

---
## Original issue: Add analytics to intent filters

It would be nice to see how many people actually open guides in the app by navigating to a guide URL.
