### PR TITLE
Fix crash when clicking comments bubble on conclusion

### DIFF
--- a/App/src/com/dozuki/ifixit/ui/guide/view/GuideViewActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/guide/view/GuideViewActivity.java
@@ -160,7 +160,7 @@ public class GuideViewActivity extends BaseMenuDrawerActivity implements
                String title, context;
 
                // If we're in one of the introduction pages, show guide comments.
-               if (stepIndex < 0 || stepIndex >= mGuide.getNumSteps()) {
+               if (GuideViewActivity.this.notOnStep(stepIndex)) {
                   comments = mGuide.getComments();
                   title = getString(R.string.guide_comments);
                   context = "guide";
@@ -191,7 +191,7 @@ public class GuideViewActivity extends BaseMenuDrawerActivity implements
             ArrayList<Comment> comments = (ArrayList<Comment>)extras.getSerializable(COMMENTS_TAG);
             int stepIndex = getStepIndex();
 
-            if (this.notOnStep(stepIndex)) {
+            if (notOnStep(stepIndex)) {
                mGuide.setComments(comments);
             } else {
                mGuide.getStep(stepIndex).setComments(comments);
@@ -217,7 +217,7 @@ public class GuideViewActivity extends BaseMenuDrawerActivity implements
          int stepIndex = getStepIndex();
 
          int commentCount = 0;
-         if (this.notOnStep(stepIndex)) {
+         if (notOnStep(stepIndex)) {
             commentCount = mGuide.getCommentCount();
          } else if (mGuide.getNumSteps() < stepIndex) {
             commentCount = mGuide.getStep(stepIndex).getCommentCount();
@@ -297,7 +297,7 @@ public class GuideViewActivity extends BaseMenuDrawerActivity implements
             String title, context;
 
             // If we're in one of the introduction pages, show guide comments.
-            if (this.notOnStep(stepIndex)) {
+            if (notOnStep(stepIndex)) {
                comments = mGuide.getComments();
                title = getString(R.string.guide_comments);
                context = "guide";


### PR DESCRIPTION
Courtesy of the Play Store:

``` java
java.lang.IndexOutOfBoundsException: Invalid index 3, size is 3
at java.util.ArrayList.throwIndexOutOfBoundsException(ArrayList.java:255)
at java.util.ArrayList.get(ArrayList.java:308)
at com.dozuki.ifixit.model.guide.Guide.getStep(Guide.java:161)
at com.dozuki.ifixit.ui.guide.view.GuideViewActivity$1.onClick(GuideViewActivity.java:169)
at android.view.View.performClick(View.java:4438)
at android.view.View$PerformClick.run(View.java:18439)
at android.os.Handler.handleCallback(Handler.java:733)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:136)
at android.app.ActivityThread.main(ActivityThread.java:5034)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:795)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:611)
at dalvik.system.NativeStart.main(Native Method)
```
