### PR TITLE
Handle QR code's with no URI segments gracefully

### DIFF
--- a/App/src/com/dozuki/ifixit/ui/topic_view/TopicViewActivity.java
+++ b/App/src/com/dozuki/ifixit/ui/topic_view/TopicViewActivity.java
@@ -12,7 +12,6 @@ import com.dozuki.ifixit.R;
 import com.dozuki.ifixit.model.topic.TopicNode;
 import com.dozuki.ifixit.ui.BaseSearchMenuDrawerActivity;
 import com.dozuki.ifixit.ui.guide.view.GuideViewActivity;
-import com.google.analytics.tracking.android.Fields;
 
 public class TopicViewActivity extends BaseSearchMenuDrawerActivity {
    public static final String TOPIC_KEY = "TOPIC";


### PR DESCRIPTION
Instead of crashing if there are no segments in the URI (ie a root url), let's
just direct the user to the root category page.
