### PR TITLE
Prepare project for Android Studio 1.0 Upgrade

### DIFF
--- a/App/build.gradle
+++ b/App/build.gradle
@@ -3,10 +3,11 @@ buildscript {
       mavenCentral()
    }
    dependencies {
-      classpath 'com.android.tools.build:gradle:0.12.2'
+      classpath 'com.android.tools.build:gradle:1.0.0'
    }
 }
-apply plugin: 'android'
+
+apply plugin: 'com.android.application'
 
 repositories {
    mavenCentral()
@@ -18,7 +19,7 @@ repositories {
 
 dependencies {
    compile fileTree(dir: 'libs', include: '*.jar')
-   compile "com.android.support:support-v4:19.0.1"
+   compile "com.android.support:support-v4:21.0.0"
    compile "com.actionbarsherlock:actionbarsherlock:4.4.0@aar"
    compile "com.squareup.okhttp:okhttp:1.3.0"
    compile "com.marczych.androidsectionheaders:androidsectionheaders:1.0.0"
@@ -64,7 +65,7 @@ android {
       release {
          buildConfigField "String", "DEV_SERVER", '""'
 
-         runProguard true
+         minifyEnabled true
          proguardFile 'proguard.cfg'
       }
    }


### PR DESCRIPTION
Android studio is finally out of Beta - which means upgrade time!  Included
with the 1.0 release, the android build team released gradle-android-plugin
1.0.0 (http://tools.android.com/tech-docs/new-build-system/migrating-to-1-0-0)
  as well as a new version of the android support library (v21).

Luckily, there were only a couple renamed properties in the new version, so the
changes are minor.

Also important to note - you need to have `gradle` v2.2.1 installed in order to
build the project.
