### PR TITLE
Gradle properties base: Add magnoliamedical

### DIFF
--- a/gradle.properties.base
+++ b/gradle.properties.base
@@ -19,3 +19,9 @@ accustreamGAPropertyId=GAPropertyId
 accustreamKeyAlias=keyalias
 accustreamStorePassword=storepassword
 accustreamKeyPassword=keypassword
+
+magnoliamedicalAppId=0123456789ABCDEF0123456789ABCDEF
+magnoliamedicalGAPropertyId=GAPropertyId
+magnoliamedicalKeyAlias=keyalias
+magnoliamedicalStorePassword=storepassword
+magnoliamedicalKeyPassword=keypassword


### PR DESCRIPTION
We added Magnolia Medical as a white labelled app in #239 but didn't add
the default values in `gradle.properties.base` so users can't build the
app without adding the necessary values.