### PR TITLE
IntentFilterActivity: Force new task

### DIFF
--- a/App/sites/accustream/AndroidManifest.xml
+++ b/App/sites/accustream/AndroidManifest.xml
@@ -12,6 +12,7 @@
 
         <activity
             android:name="com.dozuki.ifixit.ui.IntentFilterActivity"
+            android:taskAffinity=""
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>

--- a/App/sites/dozuki/AndroidManifest.xml
+++ b/App/sites/dozuki/AndroidManifest.xml
@@ -32,6 +32,7 @@
 
         <activity
             android:name="com.dozuki.ifixit.ui.IntentFilterActivity"
+            android:taskAffinity=""
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>

--- a/App/sites/dripassist/AndroidManifest.xml
+++ b/App/sites/dripassist/AndroidManifest.xml
@@ -12,6 +12,7 @@
 
         <activity
             android:name="com.dozuki.ifixit.ui.IntentFilterActivity"
+            android:taskAffinity=""
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>

--- a/App/sites/ifixit/AndroidManifest.xml
+++ b/App/sites/ifixit/AndroidManifest.xml
@@ -12,6 +12,7 @@
 
         <activity
             android:name="com.dozuki.ifixit.ui.IntentFilterActivity"
+            android:taskAffinity=""
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>

--- a/App/sites/magnoliamedical/AndroidManifest.xml
+++ b/App/sites/magnoliamedical/AndroidManifest.xml
@@ -12,6 +12,7 @@
 
         <activity
             android:name="com.dozuki.ifixit.ui.IntentFilterActivity"
+            android:taskAffinity=""
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
In order to make the back button behave properly when coming from search
results or other intents, we must force `IntentFilterActivity` to have a
different `taskAffinity` so it doesn't launch the activities into the
same stack as the main application. This results in an empty back stack
for all Activities routed through `IntentFilterActivity` which is
exactly what we want.