### PR TITLE
Fix SAML login error

### DIFF
--- a/App/build.gradle
+++ b/App/build.gradle
@@ -13,7 +13,7 @@ repositories {
    mavenCentral()
    mavenLocal() // Needed to pick up analytics from maven-android-sdk-deployer
    maven {
-      url 'https://raw.github.com/iFixit/ark/master/releases/'
+      url 'https://github.com/iFixit/ark/raw/master/releases/'
    }
 }
 
@@ -48,8 +48,8 @@ android {
    buildToolsVersion "21.1.2"
 
    defaultConfig {
-      versionCode 60 
-      versionName "2.9.2"
+      versionCode 61
+      versionName "2.9.3"
       minSdkVersion 9
       targetSdkVersion 21
       applicationId "com.dozuki.ifixit"


### PR DESCRIPTION
SAML login for most customers was broken.

The WebView logic that checks for the session cookies returned by the Clients
login form was tricked into thinking that it was on the dozuki domain, when
really it was still on the SAML login page. This is because we use a "Black
List" when deciding if we shouldn't capture and return the cookies. That black
list was capturing some false positives due to query params in SAML urls that
include the dozuki hostname.

The solution was to make the regex/string-comparison stricter to only look at
the first part of the domain, rather than anywhere in the URL string.