### PR TITLE
Fix broken camera permissions Pre-oreo

### DIFF
--- a/App/build.gradle
+++ b/App/build.gradle
@@ -59,8 +59,8 @@ android {
    buildToolsVersion "25.0.2"
 
    defaultConfig {
-      versionCode 67
-      versionName "3.0.6"
+      versionCode 68
+      versionName "3.0.7"
       minSdkVersion 14
       targetSdkVersion 23
       applicationId "com.dozuki.ifixit"

--- a/App/src/com/dozuki/ifixit/ui/gallery/MediaFragment.java
+++ b/App/src/com/dozuki/ifixit/ui/gallery/MediaFragment.java
@@ -301,20 +301,17 @@ public abstract class MediaFragment extends BaseFragment
       try {
          file = CaptureHelper.createImageFile(getActivity());
          mCameraTempFileName = file.getAbsolutePath();
-         Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-         // Ensure that there's a camera activity to handle the intent
-         if (takePictureIntent.resolveActivity(getContext().getPackageManager()) != null) {
+         Context context = getContext();
+         Intent i = CaptureHelper.getCaptureIntent(context, file);
 
-            // Continue only if the File was successfully created
-            if (file != null) {
-               Context context = getContext();
-               Uri photoURI = FileProvider.getUriForFile(context,
-                context.getPackageName() + ".fileprovider",
-                file);
-               takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
-               startActivityForResult(takePictureIntent, CaptureHelper.CAMERA_REQUEST_CODE);
-            }
+         // Ensure that there's a camera activity to handle the intent
+         if (i.resolveActivity(context.getPackageManager()) == null) {
+            Toast.makeText(getActivity(), "We had a problem launching your camera.", Toast.LENGTH_SHORT).show();
+            return;
          }
+
+         startActivityForResult(i, CaptureHelper.CAMERA_REQUEST_CODE);
+
       } catch (IOException e) {
          Log.e("MediaFragment", "Launch camera", e);
          Toast.makeText(getActivity(), "We had a problem launching your camera.", Toast.LENGTH_SHORT).show();

--- a/App/src/com/dozuki/ifixit/ui/guide/create/StepEditImageFragment.java
+++ b/App/src/com/dozuki/ifixit/ui/guide/create/StepEditImageFragment.java
@@ -3,10 +3,13 @@ package com.dozuki.ifixit.ui.guide.create;
 import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ClipData;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
@@ -36,6 +39,7 @@ import com.squareup.otto.Bus;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class StepEditImageFragment extends BaseFragment {
 
@@ -84,7 +88,6 @@ public class StepEditImageFragment extends BaseFragment {
          mThumbs.setCanEdit(false);
          ActivityCompat.requestPermissions(getActivity(),
           permissions, CaptureHelper.PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE);
-
       } else {
          mThumbs.setCanEdit(true);
       }
@@ -139,20 +142,17 @@ public class StepEditImageFragment extends BaseFragment {
                             // Create the File where the photo should go
                             File photoFile = CaptureHelper.createImageFile(getActivity());
                             mCurrentPhotoPath = photoFile.getAbsolutePath();
-                            Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+
+                            Intent i = CaptureHelper.getCaptureIntent(mContext, photoFile);
+
                             // Ensure that there's a camera activity to handle the intent
-                            if (takePictureIntent.resolveActivity(mContext.getPackageManager()) != null) {
-                               // Continue only if the File was successfully created
-                               if (photoFile != null) {
-                                  Uri photoURI = FileProvider.getUriForFile(mContext,
-                                   mContext.getPackageName() + ".fileprovider",
-                                   photoFile);
-                                  takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
-                                  startActivityForResult(takePictureIntent, CaptureHelper.CAMERA_REQUEST_CODE);
-                               } else {
-                                  Log.d("CaptureHelper", "photo file is null");
-                               }
+                            if (i.resolveActivity(mContext.getPackageManager()) == null) {
+                               Toast.makeText(getActivity(), "We had a problem launching your camera.", Toast.LENGTH_SHORT).show();
+                               break;
                             }
+
+                            startActivityForResult(i, CaptureHelper.CAMERA_REQUEST_CODE);
+
                          } catch (IOException e) {
                             Log.e("StepEditImageFragment", "Launch camera", e);
                             Toast.makeText(getActivity(), "We had a problem launching your camera.", Toast.LENGTH_SHORT).show();

--- a/App/src/com/dozuki/ifixit/util/api/ApiCall.java
+++ b/App/src/com/dozuki/ifixit/util/api/ApiCall.java
@@ -338,7 +338,7 @@ public class ApiCall {
    }
 
    public static ApiCall copyImage(String query) {
-      return new ApiCall(ApiEndpoint.COPY_IMAGE, query);
+      return new ApiCall(ApiEndpoint.COPY_IMAGE, query, RequestBody.create(JSON, ""));
    }
 
    public static ApiCall userImages(String query) {


### PR DESCRIPTION
Due to some permissions and FileProvider changes the last release, older devices didn't have access to the filesystem, and the `Camera` intent couldn't write the files, causing the app to crash. This fixes that.

Also, CopyImage API call was broken due to okhttp requiring a body for POST requests.  Also fixed.